### PR TITLE
added some plugins

### DIFF
--- a/plugins.txt
+++ b/plugins.txt
@@ -44,3 +44,8 @@ configuration-as-code  # allows fully bootstrapped Jenkins without any manual co
 configuration-as-code-support
 job-dsl  # allows programmatic creation of projects using a DSL
 envinject  # Environment Injector: setup a custom environment for jobs
+bouncycastle-api:2.18  # update required by ghprb plugin
+xml-job-to-job-dsl:0.1.13  # to view the DSL of existing pipelines
+ghprb:1.42.1  # GitHub PR Builder
+slack:2.42  # slack integration
+github-pullrequest:0.2.8  # variant of ghprb, with PR status update

--- a/plugins.txt
+++ b/plugins.txt
@@ -43,8 +43,8 @@ ansicolor  # adds support for ANSI escape sequences, including color, to Console
 configuration-as-code  # allows fully bootstrapped Jenkins without any manual configurations
 job-dsl  # allows programmatic creation of projects using a DSL
 envinject  # Environment Injector: setup a custom environment for jobs
-bouncycastle-api:2.18  # update required by ghprb plugin
-xml-job-to-job-dsl:0.1.13  # to view the DSL of existing pipelines
-ghprb:1.42.1  # GitHub PR Builder
-slack:2.42  # slack integration
-github-pullrequest:0.2.8  # variant of ghprb, with PR status update
+bouncycastle-api  # update required by ghprb plugin
+xml-job-to-job-dsl  # to view the DSL of existing pipelines
+ghprb:1.42.1  # GitHub PR Builder. Tagged to avoid potential security issue with this plugin.
+slack  # slack integration
+github-pullrequest  # variant of ghprb, with PR status update

--- a/plugins.txt
+++ b/plugins.txt
@@ -41,7 +41,6 @@ mailer  # Mailer
 
 ansicolor  # adds support for ANSI escape sequences, including color, to Console Output.
 configuration-as-code  # allows fully bootstrapped Jenkins without any manual configurations
-configuration-as-code-support
 job-dsl  # allows programmatic creation of projects using a DSL
 envinject  # Environment Injector: setup a custom environment for jobs
 bouncycastle-api:2.18  # update required by ghprb plugin


### PR DESCRIPTION
For DACCS pipeline, these plugins need to be installed before job DSL gets uploaded to instance.
Otherwise, some DSL operations are not supported and instance crashes on boot.

Also remove 'configuration-as-code-support', since outdated last year, not found while building image.